### PR TITLE
feat: add machine registry to manifest metadata and use brew leaves

### DIFF
--- a/README.md
+++ b/README.md
@@ -7,6 +7,13 @@ Synchronize your Homebrew packages across multiple machines using a declarative 
 - [Installation](#installation)
 - [Quick Start](#quick-start)
 - [Commands](#commands)
+  - [init](#brew-sync-init)
+  - [status](#brew-sync-status)
+  - [apply](#brew-sync-apply)
+  - [reconcile](#brew-sync-reconcile)
+  - [merge](#brew-sync-merge)
+  - [push](#brew-sync-push)
+  - [pull](#brew-sync-pull)
 - [Configuration](#configuration)
 - [The Manifest File](#the-manifest-file)
 - [Machine-Specific Packages](#machine-specific-packages)
@@ -46,7 +53,7 @@ make install
 brew-sync init
 ```
 
-This scans your Homebrew installation and creates a `brew-sync.toml` manifest with all your currently installed formulae, casks, and taps.
+This scans your Homebrew installation and creates a `brew-sync.toml` manifest with your explicitly installed formulae, casks, and taps. Dependencies are excluded — Homebrew pulls them in automatically.
 
 ```
 Manifest written to brew-sync.toml (47 formulae, 12 casks, 3 taps)
@@ -117,7 +124,7 @@ Generates a manifest from your current Homebrew installation.
 brew-sync init
 ```
 
-This creates `brew-sync.toml` (or the path set in your config) containing all locally installed formulae, casks, and taps. Packages are sorted alphabetically. No machine filters are applied — the snapshot reflects exactly what is installed.
+This creates `brew-sync.toml` (or the path set in your config) containing your explicitly installed formulae (via `brew leaves`), casks, and taps. Dependencies are excluded — Homebrew installs them automatically. Packages are sorted alphabetically. No machine filters are applied.
 
 ### `brew-sync status`
 
@@ -211,9 +218,23 @@ Manifest updated: 1 added for all machines, 1 added for this machine only, 1 ski
 
 This is useful after pulling a manifest from another machine to incorporate packages unique to this one.
 
+### `brew-sync merge`
+
+Non-interactive alternative to `reconcile`. Unions your local Homebrew state into the existing manifest — adds any packages not already present and updates versions of existing packages to match local state. Packages in the manifest but not installed locally are preserved (they belong to other machines).
+
+```bash
+brew-sync merge
+```
+
+```
+Manifest merged: 5 added, 3 versions updated (52 formulae, 14 casks, 4 taps)
+```
+
+This is equivalent to running `reconcile` and choosing "add for all machines" for every local-only package. Use `reconcile` instead if you want to selectively mark some packages as machine-specific.
+
 ### `brew-sync push`
 
-Snapshots your local Homebrew state, builds a manifest, and pushes it to the configured remote backend.
+Snapshots your explicitly installed packages (not dependencies), builds a manifest, and pushes it to the configured remote backend.
 
 ```bash
 brew-sync push
@@ -290,7 +311,7 @@ remote_path = "/Volumes/shared/brew-sync.toml"
 
 ## The Manifest File
 
-The manifest (`brew-sync.toml`) is a TOML file that declares your desired packages.
+The manifest (`brew-sync.toml`) is a TOML file that declares your desired packages. It tracks only top-level packages you explicitly installed — not their transitive dependencies. Homebrew manages dependencies automatically when you install a formula, so the manifest stays lean and focused on what you actually chose to install.
 
 ### Example
 
@@ -301,6 +322,7 @@ version = 1
 updated_at = "2025-01-15T10:30:00Z"
 updated_by = "alice"
 machine = "alice-macbook"
+machines = ["alice-macbook", "work-laptop", "home-desktop"]
 
 taps = ["homebrew/cask-fonts", "hashicorp/tap"]
 
@@ -328,7 +350,8 @@ except_on = ["home-desktop"]
 - `version` — Schema version (must be `1`)
 - `metadata.updated_at` — Timestamp of last update
 - `metadata.updated_by` — Who last updated the manifest
-- `metadata.machine` — Machine that generated the manifest
+- `metadata.machine` — Machine that last wrote the manifest
+- `metadata.machines` — All machines that have contributed to this manifest
 - `taps` — Third-party Homebrew repositories (format: `owner/repo`)
 - `formulae` — Command-line packages
 - `casks` — GUI application packages
@@ -355,6 +378,20 @@ brew-sync validates the manifest and reports all errors at once:
 ## Machine-Specific Packages
 
 Use `only_on` and `except_on` to control which packages install on which machines. The machine is identified by the `machine_tag` in your config file.
+
+**Important**: Set `machine_tag` in your config on every machine. Without it, machine-specific filtering is disabled and `reconcile` won't offer the option to pin packages to this machine.
+
+```toml
+# ~/.config/brew-sync/config.toml
+machine_tag = "work-macbook"
+```
+
+Every time a machine writes to the manifest (via `init`, `push`, `merge`, or `reconcile`), its tag is added to the `machines` list in the metadata. This gives you a registry of all machines in the sync group:
+
+```toml
+[metadata]
+machines = ["home-desktop", "work-macbook"]
+```
 
 ### Install only on specific machines
 
@@ -429,7 +466,7 @@ brew-sync push
 On the new machine:
 
 ```bash
-# Create a config file with the same sync backend
+# Create a config file — set a unique machine_tag for this machine
 mkdir -p ~/.config/brew-sync
 cat > ~/.config/brew-sync/config.toml << 'EOF'
 manifest_path = "brew-sync.toml"
@@ -444,7 +481,7 @@ EOF
 brew-sync pull
 brew-sync status          # review what will change
 brew-sync apply           # install missing packages, upgrade outdated ones
-brew-sync reconcile       # add local-only packages to the manifest
+brew-sync reconcile       # add local-only packages (choose per-machine or all)
 brew-sync push            # push updated manifest back
 ```
 
@@ -460,11 +497,15 @@ brew-sync apply
 ### After installing new packages manually
 
 ```bash
-# Push updated state to remote
+# Option 1: Push a full snapshot (overwrites manifest with local state)
+brew-sync push
+
+# Option 2: Merge local packages into the existing manifest (preserves other machines' packages)
+brew-sync merge
 brew-sync push
 ```
 
-Other machines can then `pull` and `apply` to pick up the new packages.
+Use `merge` + `push` when other machines have already added packages to the manifest that you don't have locally — a plain `push` would drop those. Use `reconcile` instead of `merge` if you want to selectively mark some packages as machine-specific.
 
 ### Safe review before applying
 

--- a/cmd/apply.go
+++ b/cmd/apply.go
@@ -61,7 +61,7 @@ Use --dry-run to preview changes without applying them.`,
 			fmt.Println("[verbose] Querying local Homebrew state...")
 		}
 
-		formulae, err := runner.ListFormulae()
+		formulae, err := runner.ListLeaves()
 		if err != nil {
 			return fmt.Errorf("failed to list formulae: %w", err)
 		}

--- a/cmd/init.go
+++ b/cmd/init.go
@@ -21,7 +21,7 @@ starting point for synchronization.`,
 		manager := manifest.NewManifestManager()
 
 		// Query local brew state
-		formulae, err := runner.ListFormulae()
+		formulae, err := runner.ListLeaves()
 		if err != nil {
 			return fmt.Errorf("failed to list formulae: %w", err)
 		}
@@ -54,7 +54,9 @@ starting point for synchronization.`,
 		}
 
 		// Build manifest from local state
-		m := manager.BuildFromLocal(localFormulae, localCasks, taps)
+		machineTag := getMachineTag(cfg)
+		updatedBy := getUpdatedBy()
+		m := manager.BuildFromLocal(localFormulae, localCasks, taps, machineTag, updatedBy)
 
 		// Save manifest to configured path
 		outputPath := getManifestPath(cfg)

--- a/cmd/integration_test.go
+++ b/cmd/integration_test.go
@@ -56,7 +56,7 @@ func TestIntegration_FullWorkflow(t *testing.T) {
 		localCasks[i] = manifest.LocalPackage{Name: pkg.Name, Version: pkg.Version}
 	}
 
-	m := manager.BuildFromLocal(localFormulae, localCasks, taps)
+	m := manager.BuildFromLocal(localFormulae, localCasks, taps, "test-machine", "testuser")
 
 	// Save manifest to a temp "local" directory
 	localDir := t.TempDir()
@@ -609,7 +609,7 @@ func TestIntegration_MergeLocal(t *testing.T) {
 	}
 	localTaps := []string{"homebrew/core", "hashicorp/tap"}
 
-	added, updated := manager.MergeLocal(m, localFormulae, localCasks, localTaps)
+	added, updated := manager.MergeLocal(m, localFormulae, localCasks, localTaps, "test-machine", "testuser")
 
 	// Verify counts
 	if added != 3 { // go + slack + hashicorp/tap

--- a/cmd/merge.go
+++ b/cmd/merge.go
@@ -35,7 +35,7 @@ for every local-only package, plus updating all version drift.`,
 
 		runner := brew.NewRealBrewRunner()
 
-		formulae, err := runner.ListFormulae()
+		formulae, err := runner.ListLeaves()
 		if err != nil {
 			return fmt.Errorf("failed to list formulae: %w", err)
 		}
@@ -60,7 +60,9 @@ for every local-only package, plus updating all version drift.`,
 			localCasks[i] = manifest.LocalPackage{Name: pkg.Name, Version: pkg.Version}
 		}
 
-		added, updated := manager.MergeLocal(m, localFormulae, localCasks, taps)
+		machineTag := getMachineTag(cfg)
+		updatedBy := getUpdatedBy()
+		added, updated := manager.MergeLocal(m, localFormulae, localCasks, taps, machineTag, updatedBy)
 
 		if err := manager.Save(manifestPath, m); err != nil {
 			return fmt.Errorf("failed to save manifest: %w", err)

--- a/cmd/push.go
+++ b/cmd/push.go
@@ -27,7 +27,7 @@ If no configuration file is found, the manifest is saved locally only.`,
 			fmt.Println("[verbose] Querying local Homebrew state...")
 		}
 
-		formulae, err := runner.ListFormulae()
+		formulae, err := runner.ListLeaves()
 		if err != nil {
 			return fmt.Errorf("failed to list formulae: %w", err)
 		}
@@ -68,10 +68,12 @@ If no configuration file is found, the manifest is saved locally only.`,
 			fmt.Println("[verbose] Building manifest from local state...")
 		}
 
-		m := manager.BuildFromLocal(localFormulae, localCasks, taps)
+		cfg, cfgErr := loadConfig(GetConfigPath())
+		machineTag := getMachineTag(cfg)
+		updatedBy := getUpdatedBy()
+		m := manager.BuildFromLocal(localFormulae, localCasks, taps, machineTag, updatedBy)
 
 		// Step 4: Save manifest locally using configured path
-		cfg, cfgErr := loadConfig(GetConfigPath())
 		outputPath := getManifestPath(cfg)
 
 		if verbose {

--- a/cmd/reconcile.go
+++ b/cmd/reconcile.go
@@ -5,6 +5,7 @@ import (
 	"fmt"
 	"os"
 	"strings"
+	"time"
 
 	"brew-sync/internal/brew"
 	"brew-sync/internal/diff"
@@ -42,7 +43,7 @@ packages that are unique to this machine.`,
 		// Query local brew state
 		runner := brew.NewRealBrewRunner()
 
-		formulae, err := runner.ListFormulae()
+		formulae, err := runner.ListLeaves()
 		if err != nil {
 			return fmt.Errorf("failed to list formulae: %w", err)
 		}
@@ -140,6 +141,10 @@ packages that are unique to this machine.`,
 
 		// Save updated manifest
 		if added+addedLocal > 0 {
+			m.Metadata.UpdatedAt = time.Now().UTC().Format(time.RFC3339)
+			m.Metadata.UpdatedBy = getUpdatedBy()
+			m.Metadata.Machine = machineTag
+			m.Metadata.Machines = manifest.AddMachineToList(m.Metadata.Machines, machineTag)
 			if err := manager.Save(manifestPath, m); err != nil {
 				return fmt.Errorf("failed to save manifest: %w", err)
 			}

--- a/cmd/root.go
+++ b/cmd/root.go
@@ -3,6 +3,7 @@ package cmd
 import (
 	"fmt"
 	"os"
+	"os/user"
 
 	"brew-sync/internal/brew"
 	"brew-sync/internal/config"
@@ -87,6 +88,13 @@ func getManifestPath(cfg *config.Config) string {
 func getMachineTag(cfg *config.Config) string {
 	if cfg != nil {
 		return cfg.MachineTag
+	}
+	return ""
+}
+// getUpdatedBy returns the current OS username for manifest metadata.
+func getUpdatedBy() string {
+	if u, err := user.Current(); err == nil {
+		return u.Username
 	}
 	return ""
 }

--- a/cmd/status.go
+++ b/cmd/status.go
@@ -33,7 +33,7 @@ Homebrew packages and display a human-readable summary of what would change.`,
 		// Query local brew state
 		runner := brew.NewRealBrewRunner()
 
-		formulae, err := runner.ListFormulae()
+		formulae, err := runner.ListLeaves()
 		if err != nil {
 			return fmt.Errorf("failed to list formulae: %w", err)
 		}

--- a/internal/brew/mock_runner.go
+++ b/internal/brew/mock_runner.go
@@ -65,6 +65,15 @@ func (m *MockBrewRunner) ListFormulae() ([]diff.Package, error) {
 	return m.Formulae, nil
 }
 
+// ListLeaves returns the same as ListFormulae for the mock (tests control the input).
+func (m *MockBrewRunner) ListLeaves() ([]diff.Package, error) {
+	m.Calls = append(m.Calls, MockCall{Operation: "list_leaves"})
+	if m.ListFormulaeErr != nil {
+		return nil, m.ListFormulaeErr
+	}
+	return m.Formulae, nil
+}
+
 // ListCasks returns the configured casks list or error.
 func (m *MockBrewRunner) ListCasks() ([]diff.Package, error) {
 	m.Calls = append(m.Calls, MockCall{Operation: "list_casks"})

--- a/internal/brew/runner.go
+++ b/internal/brew/runner.go
@@ -12,6 +12,9 @@ import (
 type BrewRunner interface {
 	// ListFormulae returns all installed Homebrew formulae with their versions.
 	ListFormulae() ([]diff.Package, error)
+	// ListLeaves returns only explicitly installed formulae (not auto-installed dependencies).
+	// These are packages the user installed directly; dependencies are pulled in automatically.
+	ListLeaves() ([]diff.Package, error)
 	// ListCasks returns all installed Homebrew casks with their versions.
 	ListCasks() ([]diff.Package, error)
 	// ListTaps returns all configured Homebrew taps.
@@ -50,6 +53,37 @@ func (r *RealBrewRunner) ListFormulae() ([]diff.Package, error) {
 		return nil, fmt.Errorf("failed to list formulae: %w", err)
 	}
 	return parseBrewListOutput(string(output)), nil
+}
+
+// ListLeaves runs `brew leaves` to get explicitly installed formulae, then
+// cross-references with `brew list --formula --versions` to attach version info.
+// This returns only top-level packages (not auto-installed dependencies).
+func (r *RealBrewRunner) ListLeaves() ([]diff.Package, error) {
+	// Get leaf names
+	leavesCmd := exec.Command("brew", "leaves")
+	leavesOutput, err := leavesCmd.Output()
+	if err != nil {
+		return nil, fmt.Errorf("failed to list leaves: %w", err)
+	}
+	leafNames := make(map[string]bool)
+	for _, name := range parseLines(string(leavesOutput)) {
+		leafNames[name] = true
+	}
+
+	// Get all formulae with versions
+	allFormulae, err := r.ListFormulae()
+	if err != nil {
+		return nil, err
+	}
+
+	// Filter to only leaves
+	var leaves []diff.Package
+	for _, pkg := range allFormulae {
+		if leafNames[pkg.Name] {
+			leaves = append(leaves, pkg)
+		}
+	}
+	return leaves, nil
 }
 
 // ListCasks runs `brew list --cask --versions` and parses the output.

--- a/internal/manifest/manager.go
+++ b/internal/manifest/manager.go
@@ -60,11 +60,27 @@ type LocalPackage struct {
 	Version string
 }
 
+// AddMachineToList adds machineTag to the machines list if non-empty and not already present.
+// Returns the updated sorted list.
+func AddMachineToList(machines []string, machineTag string) []string {
+	if machineTag == "" {
+		return machines
+	}
+	for _, m := range machines {
+		if m == machineTag {
+			return machines
+		}
+	}
+	machines = append(machines, machineTag)
+	sort.Strings(machines)
+	return machines
+}
+
 // BuildFromLocal creates a new Manifest from the locally installed Homebrew packages.
 // It converts LocalPackage entries to PackageEntry (no machine filters), sorts
 // formulae and casks by name, sorts taps alphabetically, sets version to 1,
-// and records the current time in metadata.
-func (mm *ManifestManager) BuildFromLocal(formulae []LocalPackage, casks []LocalPackage, taps []string) *Manifest {
+// and records the current time, machine tag, and user in metadata.
+func (mm *ManifestManager) BuildFromLocal(formulae []LocalPackage, casks []LocalPackage, taps []string, machineTag, updatedBy string) *Manifest {
 	manifestFormulae := make([]PackageEntry, len(formulae))
 	for i, pkg := range formulae {
 		manifestFormulae[i] = PackageEntry{
@@ -95,6 +111,9 @@ func (mm *ManifestManager) BuildFromLocal(formulae []LocalPackage, casks []Local
 		Version: 1,
 		Metadata: ManifestMetadata{
 			UpdatedAt: time.Now().UTC().Format(time.RFC3339),
+			UpdatedBy: updatedBy,
+			Machine:   machineTag,
+			Machines:  AddMachineToList(nil, machineTag),
 		},
 		Formulae: manifestFormulae,
 		Casks:    manifestCasks,
@@ -106,7 +125,7 @@ func (mm *ManifestManager) BuildFromLocal(formulae []LocalPackage, casks []Local
 // It adds packages not already present and updates versions of existing packages
 // to match local state. Packages in the manifest but not installed locally are preserved.
 // Returns counts of added and version-updated packages.
-func (mm *ManifestManager) MergeLocal(m *Manifest, localFormulae, localCasks []LocalPackage, taps []string) (added, updated int) {
+func (mm *ManifestManager) MergeLocal(m *Manifest, localFormulae, localCasks []LocalPackage, taps []string, machineTag, updatedBy string) (added, updated int) {
 	// Index existing manifest entries
 	formulaeIdx := make(map[string]int, len(m.Formulae))
 	for i, e := range m.Formulae {
@@ -162,6 +181,9 @@ func (mm *ManifestManager) MergeLocal(m *Manifest, localFormulae, localCasks []L
 
 	// Update metadata
 	m.Metadata.UpdatedAt = time.Now().UTC().Format(time.RFC3339)
+	m.Metadata.UpdatedBy = updatedBy
+	m.Metadata.Machine = machineTag
+	m.Metadata.Machines = AddMachineToList(m.Metadata.Machines, machineTag)
 
 	return added, updated
 }

--- a/internal/manifest/manager_test.go
+++ b/internal/manifest/manager_test.go
@@ -310,7 +310,7 @@ func TestValidate_MultipleErrors(t *testing.T) {
 
 func TestBuildFromLocal_Empty(t *testing.T) {
 	mgr := NewManifestManager()
-	m := mgr.BuildFromLocal(nil, nil, nil)
+	m := mgr.BuildFromLocal(nil, nil, nil, "", "")
 
 	if m.Version != 1 {
 		t.Errorf("Version: got %d, want 1", m.Version)
@@ -352,7 +352,7 @@ func TestBuildFromLocal_Populated(t *testing.T) {
 	taps := []string{"hashicorp/tap", "homebrew/core"}
 
 	before := time.Now().UTC()
-	m := mgr.BuildFromLocal(formulae, casks, taps)
+	m := mgr.BuildFromLocal(formulae, casks, taps, "test-machine", "testuser")
 	after := time.Now().UTC()
 
 	// Version
@@ -429,7 +429,7 @@ func TestBuildFromLocal_SortsEntries(t *testing.T) {
 	}
 	taps := []string{"z-org/z-repo", "a-org/a-repo", "m-org/m-repo"}
 
-	m := mgr.BuildFromLocal(formulae, casks, taps)
+	m := mgr.BuildFromLocal(formulae, casks, taps, "", "")
 
 	// Verify formulae are sorted
 	formulaeNames := make([]string, len(m.Formulae))

--- a/internal/manifest/types.go
+++ b/internal/manifest/types.go
@@ -10,10 +10,12 @@ type Manifest struct {
 }
 
 // ManifestMetadata contains information about when and where the manifest was last updated.
+// Machines accumulates every machine tag that has written to this manifest.
 type ManifestMetadata struct {
-	UpdatedAt string `toml:"updated_at"`
-	UpdatedBy string `toml:"updated_by"`
-	Machine   string `toml:"machine"`
+	UpdatedAt string   `toml:"updated_at"`
+	UpdatedBy string   `toml:"updated_by"`
+	Machine   string   `toml:"machine"`
+	Machines  []string `toml:"machines,omitempty"`
 }
 
 // PackageEntry represents a single package in the manifest with optional machine filters.


### PR DESCRIPTION
- Populate metadata.updated_by and metadata.machine on every manifest write (init, push, merge, reconcile) using config machine_tag and OS username
- Add metadata.machines list that accumulates all machine tags that have contributed to the manifest, enabling validation of only_on/except_on tags
- Switch from `brew list --formula` to `brew leaves` so the manifest only tracks explicitly installed packages, not transitive dependencies
- Add ListLeaves() to BrewRunner interface backed by `brew leaves`
- Update README with merge command docs, machines field, and leaves behavior
- Update tests for new BuildFromLocal/MergeLocal signatures