### PR TITLE
Fix tap-prefixed leaves and tilde expansion in paths

### DIFF
--- a/README.md
+++ b/README.md
@@ -282,7 +282,7 @@ The example config includes step-by-step instructions for setting up GitHub as y
 
 ```toml
 # Path to the manifest file (default: brew-sync.toml)
-manifest_path = "brew-sync.toml"
+manifest_path = "~/.config/brew-sync/brew-sync.toml"
 
 # Identifier for this machine, used for per-machine package filtering
 machine_tag = "work-macbook"
@@ -469,7 +469,7 @@ On the new machine:
 # Create a config file — set a unique machine_tag for this machine
 mkdir -p ~/.config/brew-sync
 cat > ~/.config/brew-sync/config.toml << 'EOF'
-manifest_path = "brew-sync.toml"
+manifest_path = "~/.config/brew-sync/brew-sync.toml"
 machine_tag = "new-macbook"
 sync_backend = "file"
 

--- a/cmd/integration_test.go
+++ b/cmd/integration_test.go
@@ -7,6 +7,7 @@ import (
 	"testing"
 
 	"brew-sync/internal/brew"
+	"brew-sync/internal/config"
 	"brew-sync/internal/diff"
 	"brew-sync/internal/manifest"
 	"brew-sync/internal/sync"
@@ -435,9 +436,7 @@ remote_path = "/shared/brew-sync.toml"
 	}
 
 	// Verify defaults when config has empty values
-	emptyCfg := &manifest.Manifest{}
-	_ = emptyCfg // just to show we're testing the zero-value path
-	emptyConfig := loadConfigGraceful()
+	emptyConfig := &config.Config{}
 	if got := getManifestPath(emptyConfig); got != defaultManifestPath {
 		t.Errorf("getManifestPath(empty): got %q, want %q", got, defaultManifestPath)
 	}

--- a/cmd/root.go
+++ b/cmd/root.go
@@ -76,11 +76,18 @@ func loadConfigGraceful() *config.Config {
 
 // getManifestPath returns the manifest path from config if set,
 // otherwise returns the default "brew-sync.toml".
+// Expands a leading ~ to the user's home directory.
 func getManifestPath(cfg *config.Config) string {
+	path := defaultManifestPath
 	if cfg != nil && cfg.ManifestPath != "" {
-		return cfg.ManifestPath
+		path = cfg.ManifestPath
 	}
-	return defaultManifestPath
+	if len(path) > 0 && path[0] == '~' {
+		if home, err := os.UserHomeDir(); err == nil {
+			path = home + path[1:]
+		}
+	}
+	return path
 }
 
 // getMachineTag returns the machine tag from config if set,

--- a/config.toml.example
+++ b/config.toml.example
@@ -11,7 +11,8 @@
 
 # Path to the manifest file that tracks your packages.
 # Default: "brew-sync.toml" in the current directory.
-manifest_path = "brew-sync.toml"
+# Use an absolute path or ~ prefix to avoid writing relative to the working directory.
+manifest_path = "~/.config/brew-sync/brew-sync.toml"
 
 # A unique identifier for this machine. Used with only_on / except_on filters
 # in the manifest to control which packages install on which machines.

--- a/internal/brew/runner.go
+++ b/internal/brew/runner.go
@@ -67,7 +67,13 @@ func (r *RealBrewRunner) ListLeaves() ([]diff.Package, error) {
 	}
 	leafNames := make(map[string]bool)
 	for _, name := range parseLines(string(leavesOutput)) {
+		// brew leaves returns tap-prefixed names for third-party packages
+		// (e.g. "cockroachdb/tap/cockroach") but brew list returns short names
+		// (e.g. "cockroach"). Store both forms so the lookup works either way.
 		leafNames[name] = true
+		if i := strings.LastIndex(name, "/"); i >= 0 {
+			leafNames[name[i+1:]] = true
+		}
 	}
 
 	// Get all formulae with versions

--- a/internal/brew/runner_test.go
+++ b/internal/brew/runner_test.go
@@ -122,3 +122,52 @@ func TestParseLines_WhitespaceTrimmed(t *testing.T) {
 		t.Errorf("line 1: got %q, want %q", got[1], "homebrew/cask")
 	}
 }
+
+// TestLeafNameMatching_TapPrefixStripping verifies that tap-prefixed names from
+// `brew leaves` (e.g. "cockroachdb/tap/cockroach") match short names from
+// `brew list --formula --versions` (e.g. "cockroach").
+func TestLeafNameMatching_TapPrefixStripping(t *testing.T) {
+	leavesOutput := "git\ncockroachdb/tap/cockroach\nmongodb/brew/mongodb-community@8.0\n"
+	formulaeOutput := "git 2.53.0\ncockroach 26.1.2\nmongodb-community@8.0 8.0.20\nreadline 8.3.3\n"
+
+	// Build leaf name map the same way ListLeaves does
+	leafNames := make(map[string]bool)
+	for _, name := range parseLines(leavesOutput) {
+		leafNames[name] = true
+		if i := len(name) - 1; i >= 0 {
+			for j := i; j >= 0; j-- {
+				if name[j] == '/' {
+					leafNames[name[j+1:]] = true
+					break
+				}
+			}
+		}
+	}
+
+	allFormulae := parseBrewListOutput(formulaeOutput)
+
+	var leaves []diff.Package
+	for _, pkg := range allFormulae {
+		if leafNames[pkg.Name] {
+			leaves = append(leaves, pkg)
+		}
+	}
+
+	// Should include git, cockroach, and mongodb-community@8.0 but NOT readline
+	if len(leaves) != 3 {
+		t.Fatalf("expected 3 leaves, got %d: %v", len(leaves), leaves)
+	}
+
+	want := map[string]string{
+		"git":                    "2.53.0",
+		"cockroach":              "26.1.2",
+		"mongodb-community@8.0": "8.0.20",
+	}
+	for _, pkg := range leaves {
+		if wantVer, ok := want[pkg.Name]; !ok {
+			t.Errorf("unexpected leaf: %s", pkg.Name)
+		} else if pkg.Version != wantVer {
+			t.Errorf("leaf %s: got version %s, want %s", pkg.Name, pkg.Version, wantVer)
+		}
+	}
+}


### PR DESCRIPTION
## Summary

Two bugs fixed:

**1. Tap-prefixed packages dropped from manifest**

`brew leaves` returns fully-qualified names for third-party tap packages (e.g. `cockroachdb/tap/cockroach`) but `brew list --formula --versions` returns short names (e.g. `cockroach`). `ListLeaves()` was doing a direct map lookup, so these never matched and were silently excluded from the manifest.

Affected packages: `cockroach`, `cockroach-sql`, `mongodb-community@8.0`

Fix: strip the tap prefix when building the leaf name lookup map.

**2. Tilde not expanded in manifest_path**

`getManifestPath()` returned the raw config value without expanding `~`, causing a literal `~/` directory to be created in the working directory instead of writing to the home directory.

Fix: expand `~` to `os.UserHomeDir()` in `getManifestPath()`.

**Also:**
- Fixed integration test that depended on filesystem state instead of explicit config
- Updated `config.toml.example` and `README.md` to use recommended manifest path

## Testing

- Added regression test for tap-prefix leaf matching
- All tests pass (`go test ./... -count=1`)
- Verified `brew-sync init` now produces 80 formulae (was 77) matching `brew leaves` output