### PR TITLE
fix: remove dead ApplyOptions.DryRun field

### DIFF
--- a/internal/diff/apply.go
+++ b/internal/diff/apply.go
@@ -49,7 +49,6 @@ func (r *ApplyReport) HasErrors() bool {
 
 // ApplyOptions controls the behavior of ApplyDiff.
 type ApplyOptions struct {
-	DryRun      bool
 	SkipRemove  bool
 	SkipInstall bool
 	OnProgress  func(operation, pkgName string)


### PR DESCRIPTION
## What

Removes the `DryRun bool` field from `ApplyOptions` in `internal/diff/apply.go`.

## Why

`ApplyDiff` never reads `ApplyOptions.DryRun` — dry-run behaviour is controlled entirely by the separate `dryRun bool` positional parameter. The dead field misleads callers into thinking `ApplyOptions{DryRun: true}` enables dry-run mode, when it has no effect.

No caller in the codebase sets this field (verified by grep).

**File changed:** `internal/diff/apply.go`

Closes #6

## How to test

1. `go build ./...` — confirms no caller references the removed field
2. `go test ./internal/diff/...` — all existing dry-run tests pass unchanged, confirming behaviour is unaffected
3. Optionally: write a test that passes `ApplyOptions{}` (without `DryRun`) with `dryRun=true` and asserts `report.Planned == true`

https://claude.ai/code/session_011Y7MbQ5fX4ZceV3YTWTAug