### PR TITLE
fix: populate ApplyReport count fields in non-dry-run mode

### DIFF
--- a/internal/diff/apply.go
+++ b/internal/diff/apply.go
@@ -128,6 +128,18 @@ func ApplyDiff(diff *DiffResult, runner Runner, dryRun bool, opts ...ApplyOption
 		}
 	}
 
+	// Populate count fields to mirror the dry-run counts for any caller that inspects them.
+	for _, r := range report.Results {
+		switch r.Operation {
+		case "install":
+			report.InstallCount++
+		case "upgrade":
+			report.UpgradeCount++
+		case "remove":
+			report.RemoveCount++
+		}
+	}
+
 	if report.HasErrors() {
 		return report, fmt.Errorf("apply completed with %d errors", report.ErrorCount)
 	}


### PR DESCRIPTION
## What

After the operation loops in `ApplyDiff`, tally `InstallCount`, `UpgradeCount`, and `RemoveCount` from `report.Results`.

## Why

These fields were only set in the dry-run path. After a real apply they remained zero, making them unreliable for any caller that reads them (e.g. structured output, metrics, future callers). The dry-run and normal paths now behave consistently.

**File changed:** `internal/diff/apply.go`

Closes #7

## How to test

1. Write a test that calls `ApplyDiff` with `dryRun=false`, a diff containing 2 installs, 1 upgrade, and 1 remove, and a mock runner
2. Assert `report.InstallCount == 2`, `report.UpgradeCount == 1`, `report.RemoveCount == 1`
3. **Before fix:** all three fields are 0
4. **After fix:** fields match the operation counts

`go test ./internal/diff/...` must pass.

https://claude.ai/code/session_011Y7MbQ5fX4ZceV3YTWTAug