### PR TITLE
fix: write manifest save-failure warning to stderr with consequence note

### DIFF
--- a/cmd/apply.go
+++ b/cmd/apply.go
@@ -147,7 +147,8 @@ Use --dry-run to preview changes without applying them.`,
 				}
 				if dirty {
 					if err := manager.Save(manifestPath, m); err != nil {
-						fmt.Printf("  ⚠ failed to save manifest: %v\n", err)
+						fmt.Fprintf(os.Stderr, "warning: failed to save updated versions to manifest: %v\n", err)
+						fmt.Fprintln(os.Stderr, "         Next run may re-attempt the same upgrades.")
 					} else {
 						fmt.Println("  ✓ manifest updated")
 					}


### PR DESCRIPTION
## What

After a successful upgrade, if writing the updated version back to the manifest fails, the warning now goes to `stderr` and includes a note explaining that the next run may re-attempt the same upgrades.

## Why

The old warning (`fmt.Printf("  ⚠ failed to save manifest: %v\n", err)`) went to stdout and gave no indication of consequence. Because the manifest on disk still held the old version number, the next `brew-sync apply` run would see the package as "outdated" and attempt to upgrade it again — a silent idempotency failure.

**File changed:** `cmd/apply.go`

Closes #10

## How to test

1. Run `brew-sync apply` in a scenario where at least one upgrade succeeds
2. Make the manifest path read-only before the apply: `chmod 444 ~/.config/brew-sync/brew-sync.toml`
3. **Before fix:** warning appears on stdout with no context
4. **After fix:** warning appears on stderr as:
   ```
   warning: failed to save updated versions to manifest: ...
            Next run may re-attempt the same upgrades.
   ```
5. Restore permissions: `chmod 644 ~/.config/brew-sync/brew-sync.toml`
6. Verify `brew-sync status` shows the previously upgraded package as needing upgrade again (demonstrating the idempotency issue)

https://claude.ai/code/session_011Y7MbQ5fX4ZceV3YTWTAug